### PR TITLE
Fix Python compat & improve install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 .pyc
 build/
+base-cmake
+lama-planner

--- a/README.md
+++ b/README.md
@@ -1,16 +1,119 @@
 # LAMA Planner
 
-This package serves as integration package and allows to use the LAMA planner either standalone or embedded in the
-[Robot Construction Kit](https://rock-robotics.org)
+This package serves as integration package and allows to use the LAMA planner either standalone or embedded in the [Robot Construction Kit](https://rock-robotics.org)
 
 The original README is located [here](./README-original.md).
+## Build & Installation
 
-## Installation
+Parts of the planner are implemented in C++, and parts are implemented in Python. The C++ code was only tested under g++ and uses hash tables from the original STL which are part of the g++ libraries but not of the C++ standard. So if you want to make the planner run under a different C++ environment, you will need to adjust the parts of the planner that use these features.
 
-For a standalone installation you can use the provided install script:
+To build and install LAMA, you can use the provided install script:
 
+```shell
+$ ./install.sh
 ```
-./install.sh
+
+By default, the resulting excutables and libraries are placed under `lama-planner/` folder. To change that, edit the installation script and change `INSTALL_DIR` variable.
+
+## Running the Planner
+
+LAMA runs in three separate phases: _translation_, _knowledge compilation_, and _search_. These are partitioned into three separate programs. The three directories `lama/translate`, `lama/preprocess` and
+`lama/search` contain these programs.
+
+To run the planner, you can simply use the Bash script `lama-planner`:
+
+```shell
+$ ./plan <domain_path> <problem_path> <result_path>
 ```
 
-In order to configure the workspace directory, change the WORKSPACE directory.
+This script contains the settings used for LAMA during IPC-6. For other possible arguments modify the run script accordingly. The search component of the planner understands four options which can be combined in any way:
+
+* `l`: Use the landmark heuristic.
+* `L`: Use preferred operators of the landmark heuristic.
+* `f`: Use the FF heuristic.
+* `F`: Use helpful actions ("preferred operators" of the FF heuristic).
+
+At least one heuristic (`l` or `f`) must be used; on average, using all features of the planner (`lLfF`) appears to produce the best results, which is therefore the default in the `lama-planner` script.
+
+The planner can be told to run in iterated mode (keep searching for better solutions) using option `i`. Note that in this case, the planner may never stop (unless it can exhaust the search space) and needs to be aborted at some point.
+
+By default, the first solution is found using best-first search, later search iterations use weighted A*. In order to use weighted A* for the first iteration as well, use option `w`.
+
+Or, you can _run the three steps of LAMA separately_ (e.g., if you want to re-use output from earlier translation/pre-processing steps):
+
+First, run:
+
+```shell
+$ /path/to/lama-planner/translate/translate.py domain.pddl problem.pddl
+```
+
+The translator will will write its result to a file called `output.sas`, which serves as an input to the next phase, knowledge compilation. The translator also writes a file called `test.groups`, which is some sort of translation key (see `sas-format.txt` in the documentation directory mentioned above). This second file is not needed by the planner, but might help you understand what the translated task looks like. It also writes a file called `all.groups` which is needed by the landmark heuristic.
+
+Second, run:
+
+```shell
+$ /path/to/lama-planner/preprocess/preprocess < output.sas
+```
+
+This will run the knowledge compilation component, writing its output to the file aptly named `output`.
+
+Finally, run:
+
+```shell
+$ /path/to/lama-planner/search/search <args>  < output
+```
+
+This runs the search component of the planner. On success, it will write a file called `sas_plan` containing the plan.
+
+## Documentation
+
+A comprehensive description of LAMA can be found in the JAIR article "[The LAMA Planner: Guiding Cost-Based Anytime Planning with Landmarks](doc/lama-jair10.pdf)" by Silvia Richter and Matthias Westphal (2010). A brief description of the planner is furthermore given in "[lama-short.pdf](doc/lama-short.pdf.
+
+The AIJ article "[Concise finite-domain representations for PDDL  planning tasks](https://www.sciencedirect.com/science/article/pii/S0004370208001926)" by Malte Helmert (2009) describes the translation component in detail.  The description is somewhat idealized, as the actual implementation has some limitations in dealing with some ADL features. Still, the article provides a fairly good description of  what the translator does (or should do, at any rate).
+
+File [sas-format.txt](doc/sas-format.txt) contains a description of the translator output format.  You will only need this if you want to use SAS+ tasks/multi-valued planning tasks within your own planner.
+
+File [pre-format.txt](doc/pre-format.txt) contains a description of the output format of the knowledge compilation component (program `preprocess`). You will only need this if you want to use the preprocessed multi-valued planning task information within your own planner.
+
+## LICENSE & CONTACT
+
+License:
+LAMA was written by Silvia Richter and Matthias Westphal,
+copyright (c) 2008 NICTA and Matthias Westphal.
+Distributed under the GNU General Public License (GPL,
+see separate licence file).
+This program uses source code of the Fast Downward planner,
+(c) 2003-2004 by Malte Helmert and Silvia Richter. Permission
+to redistribute this code under the terms of the GPL has been
+granted.
+
+Note of Caution: Please be aware that LAMA has bugs. In particular the
+component responsible for parsing and translating the PDDL input has
+known problems. However, for all classical (i.e. non-numerical, no
+preferences etc.) tasks from past international planning competitions,
+formulations exist that LAMA can parse. E.g.: for Airport, use the
+STRIPS formulation. For Freecell (IPC 2002), the untyped variant. For
+Philosophers, Optical Telegraph and PSR, use the ADL variant with
+derived predicates. For Mprime and Assembly, domain files are included
+in this distribution in the "bench-patch" directory which correct
+known bugs of the competition files (Mprime) or features not supported
+by LAMA (Assembly).
+
+If you encounter further problems, please email me at
+silvia.richter@nicta.com.au. The lama/translate directory also
+contains a patch that can be applied to skip the invariant generation
+step in the translator component. This eliminates many problems and
+may be helpful e.g. if you are interested in using the framework of
+LAMA with a heuristic other than the landmark heuristic.
+
+Lastly, I would be happy to know if you are using LAMA. Just drop me a
+short email at the above address. Then I can also inform you about bug
+fixes and new versions.
+
+### Questions and Feedback
+
+Please feel free to e-mail us at silvia.richter@nicta.com.au if you have any questions, encounter bugs, or would like to discuss any issues regarding the planner.
+
+Have fun,
+
+Silvia Richter & Matthias Westphal

--- a/README.md
+++ b/README.md
@@ -77,38 +77,15 @@ File [pre-format.txt](doc/pre-format.txt) contains a description of the output f
 
 ## LICENSE & CONTACT
 
-License:
-LAMA was written by Silvia Richter and Matthias Westphal,
-copyright (c) 2008 NICTA and Matthias Westphal.
-Distributed under the GNU General Public License (GPL,
-see separate licence file).
-This program uses source code of the Fast Downward planner,
-(c) 2003-2004 by Malte Helmert and Silvia Richter. Permission
-to redistribute this code under the terms of the GPL has been
-granted.
+LAMA was written by Silvia Richter and Matthias Westphal, copyright (c) 2008 NICTA and Matthias Westphal. Distributed under the GNU General Public License (GPL, see separate licence file).
 
-Note of Caution: Please be aware that LAMA has bugs. In particular the
-component responsible for parsing and translating the PDDL input has
-known problems. However, for all classical (i.e. non-numerical, no
-preferences etc.) tasks from past international planning competitions,
-formulations exist that LAMA can parse. E.g.: for Airport, use the
-STRIPS formulation. For Freecell (IPC 2002), the untyped variant. For
-Philosophers, Optical Telegraph and PSR, use the ADL variant with
-derived predicates. For Mprime and Assembly, domain files are included
-in this distribution in the "bench-patch" directory which correct
-known bugs of the competition files (Mprime) or features not supported
-by LAMA (Assembly).
+This program uses source code of the Fast Downward planner, (c) 2003-2004 by Malte Helmert and Silvia Richter. Permission to redistribute this code under the terms of the GPL has been granted.
 
-If you encounter further problems, please email me at
-silvia.richter@nicta.com.au. The lama/translate directory also
-contains a patch that can be applied to skip the invariant generation
-step in the translator component. This eliminates many problems and
-may be helpful e.g. if you are interested in using the framework of
-LAMA with a heuristic other than the landmark heuristic.
+Note of Caution: Please be aware that LAMA has bugs. In particular the component responsible for  parsing and translating the PDDL input has known problems. However, for all classical (i.e. non-numerical, no preferences etc.) tasks from past international planning competitions, formulations exist that LAMA can parse. E.g.: for Airport, use the STRIPS formulation. For Freecell (IPC 2002), the untyped variant. For Philosophers, Optical Telegraph and PSR, use the ADL variant with derived predicates. For Mprime and Assembly, domain files are included in this distribution in the  "bench-patch" directory which correct known bugs of the competition files (Mprime) or features not supported by LAMA (Assembly).
 
-Lastly, I would be happy to know if you are using LAMA. Just drop me a
-short email at the above address. Then I can also inform you about bug
-fixes and new versions.
+If you encounter further problems, please email me at silvia.richter@nicta.com.au. The lama/translate directory also contains a patch that can be applied to skip the invariant generation step in the translator component. This eliminates many problems and may be helpful e.g. if you are interested in using the framework of LAMA with a heuristic other than the landmark heuristic.
+
+Lastly, I would be happy to know if you are using LAMA. Just drop me a short email at the above address. Then I can also inform you about bug fixes and new versions.
 
 ### Questions and Feedback
 

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+
+MAINDIR=$PWD
+INSTALL_DIR=$PWD/lama-planner
+
+rm -rf $INSTALL_DIR
+
+git clone https://github.com/rock-planning/planning-lama.git $INSTALL_DIR
+cd $INSTALL_DIR && install.sh && cd ..
+
+

--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -6,6 +6,7 @@ INSTALL_DIR=$PWD/lama-planner
 rm -rf $INSTALL_DIR
 
 git clone https://github.com/rock-planning/planning-lama.git $INSTALL_DIR
-cd $INSTALL_DIR && install.sh && cd ..
+cd $INSTALL_DIR && ./install.sh && cd ..
+
 
 

--- a/install.sh
+++ b/install.sh
@@ -1,12 +1,12 @@
 #!/bin/bash
 
 MAINDIR=$PWD
-
-
 INSTALL_DIR=$PWD/lama-planner
 
-# Get, compile, and install base-cmaks share libs
-rm -rf base-cmake
+# Cleanup previous install
+rm -rf  $INSTALL_DIR build base-cmake
+
+# Get, compile, and install CMAKE Rock share libs
 git clone https://github.com/rock-core/base-cmake.git base-cmake
 cd base-cmake
 mkdir build && cd build
@@ -22,5 +22,7 @@ make install
 
 export PATH=$INSTALL_DIR/bin:$PATH
 
+echo
+echo "LAMA planner installed in folder $INSTALL_DIR"
 lama-planner --help
 

--- a/install.sh
+++ b/install.sh
@@ -2,22 +2,20 @@
 
 MAINDIR=$PWD
 
-WORKSPACE=$PWD/planning-ws
-mkdir $WORKSPACE && cd $WORKSPACE
 
-INSTALL_DIR=$WORKSPACE/install
+INSTALL_DIR=$PWD/lama-planner
 
+# Get, compile, and install base-cmaks share libs
+rm -rf base-cmake
 git clone https://github.com/rock-core/base-cmake.git base-cmake
-git clone https://github.com/rock-planning/planning-lama.git lama
-
-cd $WORKSPACE/base-cmake
+cd base-cmake
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ..
 make install
-
 export Rock_DIR=$INSTALL_DIR/share/rock/cmake/
 
-cd $WORKSPACE/lama
+# compile & install LAMA
+cd $MAINDIR
 mkdir build && cd build
 cmake -DCMAKE_INSTALL_PREFIX=$INSTALL_DIR ..
 make install

--- a/lama/translate/invariant_finder.py
+++ b/lama/translate/invariant_finder.py
@@ -87,6 +87,14 @@ def get_initial_invariants(task):
 MAX_CANDIDATES = 100000
 MAX_TIME = 300
 
+def take_time():
+    # time.clock() deprecated in Python < 3.8 https://bit.ly/3oBIa6c
+    try:
+        return time.process_time()    # Python 3.8
+    except:
+        return time.clock()    # Python < 3.8
+
+
 def find_invariants(task, reachable_action_params):
     candidates = deque(get_initial_invariants(task))
     print(len(candidates), "initial candidates")
@@ -99,10 +107,10 @@ def find_invariants(task, reachable_action_params):
             candidates.append(invariant)
             seen_candidates.add(invariant)
 
-    start_time = time.clock()
+    start_time = take_time()
     while candidates:
         candidate = candidates.popleft()
-        if time.clock() - start_time > MAX_TIME:
+        if take_time() - start_time > MAX_TIME:
             print("Time limit reached, aborting invariant generation")
             return
         if candidate.check_balance(balance_checker, enqueue_func):

--- a/plan.in
+++ b/plan.in
@@ -1,9 +1,10 @@
 #! /bin/sh
 
 # Paths to planner components
-TRANSLATE="@CMAKE_INSTALL_PREFIX@/lib/lama/translate/translate.py"
-PREPROCESS=`which lama-planner-preprocess`
-SEARCH=`which lama-planner-search`
+ROOT="@CMAKE_INSTALL_PREFIX@"
+TRANSLATE="$ROOT/lib/lama/translate/translate.py"
+PREPROCESS="$ROOT/bin/lama-planner-preprocess"
+SEARCH="$ROOT/bin/lama-planner-search"
 
 run_planner() {
     echo "1. Running translator: $TRANSLATE"
@@ -27,7 +28,7 @@ check_input_files() {
 
 # Make sure we have exactly 3 command line arguments
 if [ $# -ne 3 ]; then
-    echo "Usage: \"plan <domain_file> <problem_file> <result_file>\""
+    echo "Usage: \"lama-planner <domain_file> <problem_file> <result_file>\""
     exit 1
 fi
 


### PR DESCRIPTION
I leave this PR if you want to use it. :-) 

I tried to build and install LAMA in a latest Linux distro and it failed (mostly because Python 3.8+ has changed way to take time and translate uses old version). I fixed that and also improved and simplified the way it is built and installed with bash script. Concretely:

--------------------
- Fixed taking time (`time.clock()`) for Python 3.8+
- Simplify install script: do not clone lama again, use current system
- Improve `lama-planner` bash script
- Report correct lama executable in install script
- Updated the README file to reflect current install and exec info